### PR TITLE
Fix unterminated f-string in citrix_netscaler_cve_2026_8451.py

### DIFF
--- a/modules/scanner/http/citrix_netscaler_cve_2026_8451.py
+++ b/modules/scanner/http/citrix_netscaler_cve_2026_8451.py
@@ -62,7 +62,7 @@ class Module(Scanner, Http_client):
 <saml2:issuer>watchTowr</saml2:issuer>
 </samlp:AuthnRequest>
 Version="2.0"
-AssertionConsumerServiceURL=""'
+AssertionConsumerServiceURL=""'''
         )
 
     @staticmethod


### PR DESCRIPTION
The `_build_saml_request` method in `modules/scanner/http/citrix_netscaler_cve_2026_8451.py` has an unterminated triple-quoted f-string on line 65.

The closing quote is a single `'` where `'''` is expected, causing:
```
unterminated triple-quoted f-string literal
```

This prevents the module from being loaded by the framework.

Fixes #3
