### PR TITLE
fix: Add interpreter timeout and bounded thread pool (#15, #16)

### DIFF
--- a/interfaces/api_server.py
+++ b/interfaces/api_server.py
@@ -16,6 +16,8 @@ import time
 import io
 import sys
 import os
+import signal
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeoutError
 from typing import Any, Dict, Optional
 
 # Ajouter le répertoire parent au PYTHONPATH pour les imports relatifs
@@ -81,6 +83,9 @@ class ApiServer:
         # Logger
         logging.basicConfig(level=logging.INFO)
         self.logger = logging.getLogger(__name__)
+        self._executor = ThreadPoolExecutor(max_workers=20, thread_name_prefix="ks-api-")
+        self._interpreter_timeout = int(os.environ.get("KITTYSPLOIT_INTERPRETER_TIMEOUT", 30))
+        self._module_timeout = int(os.environ.get("KITTYSPLOIT_MODULE_TIMEOUT", 300))
         self._configure_cors()
         
         # Initialize registry service if available (mode serveur registry uniquement)
@@ -426,10 +431,8 @@ class ApiServer:
             # Configurer la redirection des sorties
             self.setup_output_redirection(client_id)
             
-            # Exécuter le module dans un thread séparé
-            thread = threading.Thread(target=self.run_module_thread, args=(module, client_id))
-            thread.daemon = True
-            thread.start()
+            # Exécuter le module dans un thread du pool (limité à max_workers)
+            self._executor.submit(self.run_module_thread, module, client_id)
             
             return jsonify({
                 'status': 'success',
@@ -579,8 +582,9 @@ class ApiServer:
                     sys.stderr = stderr
                     
                     try:
-                        # Exécuter le code directement avec runsource
-                        exec_result = interpreter.runsource(code)
+                        # Exécuter le code avec timeout via ThreadPoolExecutor
+                        future = self._executor.submit(interpreter.runsource, code)
+                        exec_result = future.result(timeout=self._interpreter_timeout)
                         
                         # Récupérer les sorties
                         output = stdout.getvalue()
@@ -593,7 +597,11 @@ class ApiServer:
                         }
                         
                         return jsonify(response)
-                        
+
+                    except FutureTimeoutError:
+                        return jsonify({
+                            'error': f'Interpreter execution exceeded {self._interpreter_timeout}s timeout'
+                        }), 504
                     finally:
                         # Restaurer stdout et stderr
                         sys.stdout = old_stdout


### PR DESCRIPTION
## Summary

Prevents resource exhaustion from unbounded thread creation and runaway interpreter code.

### Issue #15: No interpreter execution timeout

The `/api/interpreter/execute` endpoint called `interpreter.runsource(code)` synchronously with no timeout. Malicious or buggy code (`while True: pass`) would block the Flask worker indefinitely.

**Fix:** Wrapped `runsource` in a `ThreadPoolExecutor` future with `future.result(timeout=...)`. Default 30 seconds, configurable via `KITTYSPLOIT_INTERPRETER_TIMEOUT`. Returns 504 Gateway Timeout when exceeded.

### Issue #16: Unbounded thread spawning

Every call to `/api/modules/<path>/run` created a new `threading.Thread` directly with no limit. An attacker making many concurrent requests could exhaust system threads.

**Fix:** Replaced raw `threading.Thread` with a bounded `ThreadPoolExecutor(max_workers=20)`. Also set up env var `KITTYSPLOIT_MODULE_TIMEOUT` for future module execution timeout enforcement.

### Files changed

- `interfaces/api_server.py`: Added `ThreadPoolExecutor`, interpreter timeout via future, and `_module_timeout` configuration

Closes https://github.com/SIA-IOTechnology/Kittysploit-framework/issues/15
Closes https://github.com/SIA-IOTechnology/Kittysploit-framework/issues/16